### PR TITLE
Fix main setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "basic-ajax",
   "version": "0.0.3",
   "description": "A very basic ajax module to get n post stuff.",
-  "main": "lib\\basic-ajax.js",
+  "main": "lib/basic-ajax.js",
   "scripts": {
     "test": "karma start"
   },


### PR DESCRIPTION
When installing this package through [JSPM](http://jspm.io/) it fails to find the javacript file, when I install it while overriding main to `lib/basic-ajax.js` everything works fine. 

```
jspm install npm:basic-ajax -o "{main: 'lib/basic-ajax.js'}"
```
